### PR TITLE
Fix: fix a bug for args config_path

### DIFF
--- a/run_fresco.py
+++ b/run_fresco.py
@@ -305,7 +305,7 @@ if __name__ == '__main__':
 
     print('=' * 100)
     print('loading configuration...')
-    with open('./config/config_carturn.yaml', "r") as f:
+    with open(opt.config_path, "r") as f:
         config = yaml.safe_load(f)
         
     for name, value in sorted(config.items()):

--- a/run_fresco.py
+++ b/run_fresco.py
@@ -149,6 +149,9 @@ def run_keyframe_translation(config):
         add_num = 3 - len(sublists[-1])
         sublists[-1] = sublists[-2][-add_num:] + sublists[-1]
         sublists[-2] = sublists[-2][:-add_num]
+
+    if not sublists[-2]:
+        del sublists[-2]
         
     print('processing %d batches:\nkeyframe indexes'%(len(sublists)), sublists)    
 


### PR DESCRIPTION
Fix: 

1. fix a bug for args config_path
2. fix a bug keyframe got empty list 

When set batch_size = 4
then keyframe got empty list and stop the running
keyframe indexes [[0, 26, 36, 54], [72, 87], [107, 122], [132, 159], [173, 183], [194, 206], [], [217, 229, 239]]